### PR TITLE
Expand E2E fixture coverage for v0.44.0–v0.45.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,39 @@
 # atlantis-tests
+
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Frunatlantis%2Fatlantis-tests.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Frunatlantis%2Fatlantis-tests?ref=badge_shield)
 
+Integration test fixture repository for [Atlantis](https://github.com/runatlantis/atlantis) E2E tests. See workflow runs at https://github.com/runatlantis/atlantis/actions/workflows/test.yml
 
-A set of terraform projects that atlantis e2e tests run on. See workflow runs in https://github.com/runatlantis/atlantis/actions/workflows/test.yml
+## Fixture Categories
 
+| Directory | Purpose | Active E2E |
+|-----------|---------|------------|
+| `standalone/` | Basic single-project plan | Yes |
+| `standalone-with-workspace/` | Workspace-based planning | Yes |
+| `multi-projects/` | Explicit multi-project config, `-p` targeting, `when_modified` fan-out | Yes |
+| `autodiscovery/` | Autodiscovery mode, `ignore_paths`, explicit precedence | Yes |
+| `detection/` | `.tf`, `.tf.json`, OpenTofu distribution detection | Yes |
+| `custom-workflows/` | Custom workflows, `PROJECT_NAME` hook env | Yes |
+| `output/` | Plan output rendering (heredoc, long-line, failure text) | Partial |
+| `drift/` | Drift detection API scaffolding (alpha) | TODO |
+
+## How E2E Works
+
+1. E2E runner creates a webhook pointing Atlantis at the test repo
+2. For each test case: clones repo → creates branch → mutates a `.tf` file → pushes → opens PR
+3. Atlantis auto-plans via webhook
+4. Runner polls commit status (`atlantis/plan`) until success/failure/timeout
+5. Optional: runner issues apply command and checks apply status
+6. Cleanup: close PR, delete branch, delete webhook
+
+## Adding Fixtures
+
+- Use `null_resource`, `terraform_data`, `local_file`, or `random` providers only
+- No cloud credentials, no external backends
+- Add unique output markers for E2E assertion (`output "xyz_marker" { value = "..." }`)
+- Add explicit project entry in root `atlantis.yaml`
+- Update `docs/coverage.md`
 
 ## License
+
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Frunatlantis%2Fatlantis-tests.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Frunatlantis%2Fatlantis-tests?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -4,18 +4,22 @@
 
 Integration test fixture repository for [Atlantis](https://github.com/runatlantis/atlantis) E2E tests. See workflow runs at https://github.com/runatlantis/atlantis/actions/workflows/test.yml
 
+> **Note:** The upstream Atlantis E2E runner currently exercises only `standalone` and
+> `standalone-with-workspace`. Other fixture directories are structured for future runner
+> expansion and require a companion `runatlantis/atlantis` PR to become actively tested.
+
 ## Fixture Categories
 
-| Directory | Purpose | Active E2E |
-|-----------|---------|------------|
-| `standalone/` | Basic single-project plan | Yes |
-| `standalone-with-workspace/` | Workspace-based planning | Yes |
-| `multi-projects/` | Explicit multi-project config, `-p` targeting, `when_modified` fan-out | Yes |
-| `autodiscovery/` | Autodiscovery mode, `ignore_paths`, explicit precedence | Yes |
-| `detection/` | `.tf`, `.tf.json`, OpenTofu distribution detection | Yes |
-| `custom-workflows/` | Custom workflows, `PROJECT_NAME` hook env | Yes |
-| `output/` | Plan output rendering (heredoc, long-line, failure text) | Partial |
-| `drift/` | Drift detection API scaffolding (alpha) | TODO |
+| Directory | Purpose | Current Status |
+|-----------|---------|----------------|
+| `standalone/` | Basic single-project plan | Active in current runner |
+| `standalone-with-workspace/` | Workspace-based planning | Active in current runner |
+| `multi-projects/` | Explicit multi-project config, `-p` targeting, `when_modified` fan-out | Fixture only; requires companion runner change |
+| `autodiscovery/` | Autodiscovery mode, `ignore_paths`, explicit precedence | Fixture only; requires companion runner change |
+| `detection/` | `.tf`, `.tf.json`, OpenTofu distribution detection | Fixture only; requires companion runner change |
+| `custom-workflows/` | Custom workflows, `PROJECT_NAME` hook env | Fixture only; requires companion runner change |
+| `output/` | Plan output rendering (heredoc, long-line, failure text) | Fixture only |
+| `drift/` | Drift detection API scaffolding (alpha) | Scaffold only |
 
 ## How E2E Works
 
@@ -23,8 +27,7 @@ Integration test fixture repository for [Atlantis](https://github.com/runatlanti
 2. For each test case: clones repo → creates branch → mutates a `.tf` file → pushes → opens PR
 3. Atlantis auto-plans via webhook
 4. Runner polls commit status (`atlantis/plan`) until success/failure/timeout
-5. Optional: runner issues apply command and checks apply status
-6. Cleanup: close PR, delete branch, delete webhook
+5. Cleanup: close PR, delete branch, delete webhook
 
 ## Adding Fixtures
 

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,5 +1,88 @@
 version: 3
+
+# Autodiscovery for projects without explicit config.
+# Only autodiscovery/included-a and autodiscovery/included-b are intentionally
+# auto-discovered; everything else has explicit project entries.
+autodiscover:
+  mode: enabled
+  ignore_paths:
+    - "autodiscovery/ignored"
+    - "drift/**"
+    - "output/failure"
+
 projects:
-- dir: standalone-with-workspace
-  workspace: staging
-- dir: standalone
+  # --- Original smoke-test fixtures (backward-compatible) ---
+  - dir: standalone
+    name: standalone
+
+  - dir: standalone-with-workspace
+    name: standalone-with-workspace
+    workspace: staging
+
+  # --- Multi-project explicit config ---
+  - dir: multi-projects/project1
+    name: project1
+    autoplan:
+      when_modified:
+        - "*.tf"
+        - "../shared-module/*.tf"
+
+  - dir: multi-projects/project2
+    name: project2
+    autoplan:
+      when_modified:
+        - "*.tf"
+        - "../shared-module/*.tf"
+
+  - dir: multi-projects/project-with-workspace
+    name: project-with-workspace
+    workspace: dev
+
+  # --- Autodiscovery: explicit takes precedence over discovered ---
+  - dir: autodiscovery/explicit
+    name: autodiscovery-explicit
+    autoplan:
+      when_modified:
+        - "*.tf"
+
+  # --- Detection: .tf, .tf.json, OpenTofu ---
+  - dir: detection/terraform-tf
+    name: detection-tf
+
+  - dir: detection/terraform-json
+    name: detection-json
+
+  - dir: detection/opentofu-basic
+    name: detection-opentofu
+    terraform_distribution: opentofu
+
+  # --- Custom workflow: PROJECT_NAME env assertion ---
+  - dir: custom-workflows/project-name-env
+    name: custom-workflow-env
+    workflow: assert-project-name
+
+  # --- Output rendering fixtures ---
+  - dir: output/heredoc
+    name: output-heredoc
+
+  - dir: output/long-line
+    name: output-long-line
+
+  - dir: output/failure
+    name: output-failure
+    workflow: intentional-failure
+    autoplan:
+      enabled: false
+
+workflows:
+  assert-project-name:
+    plan:
+      steps:
+        - run: sh ../scripts/assert-project-name.sh
+        - init
+        - plan
+
+  intentional-failure:
+    plan:
+      steps:
+        - run: echo "ATLANTIS_E2E_FAILURE_MARKER" && exit 1

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -8,6 +8,7 @@ autodiscover:
   ignore_paths:
     - "autodiscovery/ignored"
     - "drift/**"
+    - "multi-projects/shared-module"
     - "output/failure"
 
 projects:

--- a/autodiscovery/README.md
+++ b/autodiscovery/README.md
@@ -1,0 +1,24 @@
+# Autodiscovery Fixture
+
+Tests Atlantis autodiscovery mode with `ignore_paths` and explicit project precedence.
+
+## Coverage (v0.45.0 #6466)
+
+- **Auto-discovered projects**: `included-a/` and `included-b/` have no explicit atlantis.yaml entry
+- **Ignored paths**: `ignored/` is in `autodiscover.ignore_paths` — targeted `-d` commands should respect this
+- **Explicit precedence**: `explicit/` has both auto-discoverable HCL AND an explicit project entry — explicit config wins
+
+## atlantis.yaml Config
+
+```yaml
+autodiscover:
+  mode: enabled
+  ignore_paths:
+    - "autodiscovery/ignored"
+```
+
+## E2E Behavior
+
+1. Modify `included-a/main.tf` → Atlantis auto-discovers and plans it
+2. `atlantis plan -d autodiscovery/ignored` → should be rejected/ignored
+3. Modify `explicit/main.tf` → uses explicit project config, not discovered defaults

--- a/autodiscovery/explicit/main.tf
+++ b/autodiscovery/explicit/main.tf
@@ -1,0 +1,9 @@
+resource "null_resource" "explicit" {
+  triggers = {
+    marker = "atlantis-e2e-explicit-override"
+  }
+}
+
+output "explicit_marker" {
+  value = "explicit-overrides-autodiscovery"
+}

--- a/autodiscovery/ignored/main.tf
+++ b/autodiscovery/ignored/main.tf
@@ -1,0 +1,9 @@
+resource "null_resource" "ignored" {
+  triggers = {
+    marker = "atlantis-e2e-should-be-ignored"
+  }
+}
+
+output "ignored_marker" {
+  value = "THIS-SHOULD-NOT-PLAN"
+}

--- a/autodiscovery/included-a/main.tf
+++ b/autodiscovery/included-a/main.tf
@@ -1,0 +1,9 @@
+resource "null_resource" "included_a" {
+  triggers = {
+    marker = "atlantis-e2e-autodiscovery-a"
+  }
+}
+
+output "autodiscovery_a_marker" {
+  value = "autodiscovery-a-planned"
+}

--- a/autodiscovery/included-b/main.tf
+++ b/autodiscovery/included-b/main.tf
@@ -1,0 +1,9 @@
+resource "null_resource" "included_b" {
+  triggers = {
+    marker = "atlantis-e2e-autodiscovery-b"
+  }
+}
+
+output "autodiscovery_b_marker" {
+  value = "autodiscovery-b-planned"
+}

--- a/custom-workflows/README.md
+++ b/custom-workflows/README.md
@@ -1,0 +1,28 @@
+# Custom Workflows Fixture
+
+Tests custom workflow execution and hook environment variables.
+
+## Coverage (v0.44.0 #6438)
+
+- **PROJECT_NAME env var**: Pre-plan hook asserts `$PROJECT_NAME` is set correctly
+- **Custom workflow steps**: `run` step executes before `init`/`plan`
+- **Script validation**: POSIX shell script with clear pass/fail output
+
+## Workflow Definition (in root atlantis.yaml)
+
+```yaml
+workflows:
+  assert-project-name:
+    plan:
+      steps:
+        - run: sh ../scripts/assert-project-name.sh
+        - init
+        - plan
+```
+
+## E2E Behavior
+
+1. Modify `project-name-env/main.tf` → triggers custom workflow
+2. `assert-project-name.sh` checks `PROJECT_NAME=custom-workflow-env`
+3. If env var missing or wrong → plan fails with "FAIL:" marker
+4. If correct → prints "PASS:" and continues to init/plan

--- a/custom-workflows/project-name-env/main.tf
+++ b/custom-workflows/project-name-env/main.tf
@@ -1,0 +1,9 @@
+resource "null_resource" "custom_workflow" {
+  triggers = {
+    marker = "atlantis-e2e-custom-workflow"
+  }
+}
+
+output "custom_workflow_marker" {
+  value = "custom-workflow-planned"
+}

--- a/custom-workflows/scripts/assert-project-name.sh
+++ b/custom-workflows/scripts/assert-project-name.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Asserts that PROJECT_NAME is set and matches expected value.
+# Used by custom workflow pre_workflow_hooks to verify v0.44.0 #6438.
+set -e
+
+EXPECTED="custom-workflow-env"
+
+if [ -z "$PROJECT_NAME" ]; then
+  echo "FAIL: PROJECT_NAME is not set"
+  exit 1
+fi
+
+if [ "$PROJECT_NAME" != "$EXPECTED" ]; then
+  echo "FAIL: PROJECT_NAME='$PROJECT_NAME' but expected '$EXPECTED'"
+  exit 1
+fi
+
+echo "PASS: PROJECT_NAME=$PROJECT_NAME"

--- a/detection/README.md
+++ b/detection/README.md
@@ -1,0 +1,23 @@
+# Detection Fixture
+
+Tests Atlantis project directory detection for different file formats and distributions.
+
+## Coverage
+
+- **`.tf` files** (v0.44.1 #6455): Standard HCL terraform project
+- **`.tf.json` files** (v0.44.1 #6455): JSON-format terraform configuration
+- **OpenTofu** (v0.45.0 #6597): Project with `terraform_distribution: opentofu`
+
+## Projects
+
+| Dir | Format | Distribution | Notes |
+|-----|--------|-------------|-------|
+| `terraform-tf/` | `.tf` | terraform | Standard detection |
+| `terraform-json/` | `.tf.json` | terraform | JSON config detection |
+| `opentofu-basic/` | `.tf` | opentofu | `terraform_distribution: opentofu` in atlantis.yaml |
+
+## E2E Behavior
+
+1. Modify `terraform-json/main.tf.json` → Atlantis detects and plans the JSON project
+2. Modify `opentofu-basic/main.tf` → Atlantis uses OpenTofu binary for plan
+3. OpenTofu fixture requires OpenTofu available in the Atlantis server PATH

--- a/detection/opentofu-basic/main.tf
+++ b/detection/opentofu-basic/main.tf
@@ -1,0 +1,9 @@
+resource "null_resource" "opentofu_project" {
+  triggers = {
+    marker = "atlantis-e2e-opentofu"
+  }
+}
+
+output "opentofu_marker" {
+  value = "planned-with-opentofu"
+}

--- a/detection/terraform-json/main.tf.json
+++ b/detection/terraform-json/main.tf.json
@@ -1,0 +1,16 @@
+{
+  "resource": {
+    "null_resource": {
+      "json_detection": {
+        "triggers": {
+          "marker": "atlantis-e2e-json-detection"
+        }
+      }
+    }
+  },
+  "output": {
+    "json_detection_marker": {
+      "value": "detected-via-dot-tf-json"
+    }
+  }
+}

--- a/detection/terraform-tf/main.tf
+++ b/detection/terraform-tf/main.tf
@@ -1,0 +1,9 @@
+resource "null_resource" "tf_detection" {
+  triggers = {
+    marker = "atlantis-e2e-tf-detection"
+  }
+}
+
+output "tf_detection_marker" {
+  value = "detected-via-dot-tf"
+}

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,66 +1,85 @@
 # Atlantis E2E Coverage Inventory
 
-## Current Fixtures
+> **Note:** As of this PR, the upstream Atlantis E2E runner (`runatlantis/atlantis/e2e/main.go`)
+> actively exercises only `standalone` and `standalone-with-workspace`. All other fixture
+> directories are structured for future runner expansion and require a companion
+> `runatlantis/atlantis` E2E runner PR to become actively tested.
 
-| Fixture | Atlantis Feature | Release Motivation | Active E2E? | Notes |
-|---------|-----------------|-------------------|-------------|-------|
-| `standalone` | Basic single-project plan/apply | Original smoke test | Yes (plan only) | No apply verification |
-| `standalone-with-workspace` | Workspace-based planning | Original smoke test | Yes (plan only) | workspace=staging |
-| `multi-projects/project1` | Explicit multi-project config | General coverage | **Yes** | `-p project1` targeting |
-| `multi-projects/project2` | Explicit multi-project config | General coverage | **Yes** | `-p project2` targeting |
-| `multi-projects/project-with-workspace` | Project + workspace combo | General coverage | **Yes** | workspace=dev |
-| `multi-projects/shared-module` | `when_modified` fan-out | General coverage | Fixture only | Needs E2E case that modifies shared module |
-| `autodiscovery/included-a` | Autodiscovery mode:enabled | v0.45.0 #6466 | **Yes** | Auto-discovered, not in explicit projects |
-| `autodiscovery/included-b` | Autodiscovery mode:enabled | v0.45.0 #6466 | Fixture only | Second auto-discovered project |
-| `autodiscovery/ignored` | `autodiscover.ignore_paths` | v0.45.0 #6466 | **Yes** (negative) | Targeted `-d` should respect ignore |
-| `autodiscovery/explicit` | Explicit overrides discovery | v0.45.0 #6466 | **Yes** | Explicit project takes precedence |
-| `detection/terraform-tf` | `.tf` file detection | v0.44.1 #6455 | **Yes** | Standard terraform project |
-| `detection/terraform-json` | `.tf.json` detection | v0.44.1 #6455 | **Yes** | JSON-format terraform |
-| `detection/opentofu-basic` | OpenTofu distribution | v0.45.0 #6597 | **Yes** | `terraform_distribution: opentofu` |
-| `custom-workflows/project-name-env` | PROJECT_NAME in hooks | v0.44.0 #6438 | **Yes** | Custom workflow asserts env var |
+## Fixture Status
+
+| Fixture | Atlantis Feature | Release Motivation | Current Status | Notes |
+|---------|-----------------|-------------------|----------------|-------|
+| `standalone` | Basic single-project plan/apply | Original smoke test | Active in current runner | Plan-only verification |
+| `standalone-with-workspace` | Workspace-based planning | Original smoke test | Active in current runner | workspace=staging |
+| `multi-projects/project1` | Explicit multi-project config | General coverage | Fixture only; requires companion runner change | `-p project1` targeting |
+| `multi-projects/project2` | Explicit multi-project config | General coverage | Fixture only; requires companion runner change | `-p project2` targeting |
+| `multi-projects/project-with-workspace` | Project + workspace combo | General coverage | Fixture only; requires companion runner change | workspace=dev |
+| `multi-projects/shared-module` | `when_modified` fan-out | General coverage | Fixture only; requires companion runner change | Triggers project1+project2 via when_modified |
+| `autodiscovery/included-a` | Autodiscovery mode:enabled | v0.45.0 #6466 | Fixture only; requires companion runner change | Auto-discovered, not in explicit projects |
+| `autodiscovery/included-b` | Autodiscovery mode:enabled | v0.45.0 #6466 | Fixture only; requires companion runner change | Second auto-discovered project |
+| `autodiscovery/ignored` | `autodiscover.ignore_paths` | v0.45.0 #6466 | Fixture only; requires companion runner change | Targeted `-d` should respect ignore |
+| `autodiscovery/explicit` | Explicit overrides discovery | v0.45.0 #6466 | Fixture only; requires companion runner change | Explicit project takes precedence |
+| `detection/terraform-tf` | `.tf` file detection | v0.44.1 #6455 | Fixture only; requires companion runner change | Standard terraform project |
+| `detection/terraform-json` | `.tf.json` detection | v0.44.1 #6455 | Fixture only; requires companion runner change | JSON-format terraform |
+| `detection/opentofu-basic` | OpenTofu distribution | v0.45.0 #6597 | Fixture only; requires companion runner change | `terraform_distribution: opentofu` |
+| `custom-workflows/project-name-env` | PROJECT_NAME in hooks | v0.44.0 #6438 | Fixture only; requires companion runner change | Custom workflow asserts env var |
 | `output/heredoc` | Heredoc/multiline diffs | v0.44.1 #6561 | Fixture only | Plan output rendering |
-| `output/long-line` | Long single-line output | v0.44.1 #6544 | Fixture only | 64KiB+ line preservation |
-| `output/failure` | Failure text on job page | v0.45.0 #6414 | **Yes** (negative) | Intentional failure with marker |
-| `drift/local-file` | Drift detection API scaffold | v0.45.0 #6360 | TODO | Needs `--enable-drift-detection` |
+| `output/long-line` | Long single-line output (>64 KiB) | v0.44.1 #6544 | Fixture only | ~88 KiB single-line value |
+| `output/failure` | Failure text on job page | v0.45.0 #6414 | Fixture only; requires companion runner change | Intentional failure with marker |
+| `drift/local-file` | Drift detection API scaffold | v0.45.0 #6360 | Scaffold only | Needs `--enable-drift-detection` server flag |
 
 ## Release Coverage Matrix
 
 | Release | Feature/Fix | Coverage Status |
 |---------|------------|----------------|
-| v0.45.0 | Drift detection/remediation APIs | Fixture scaffold only — needs dedicated E2E mode with `--enable-drift-detection` |
+| v0.45.0 | Drift detection/remediation APIs | Scaffold only — needs `--enable-drift-detection` and dedicated E2E mode |
 | v0.45.0 | Localization (`--language`) | Follow-up — requires server-side config, not repo-level |
 | v0.45.0 | Automerge controls | Follow-up — risky in live test repo, needs isolated fork |
-| v0.45.0 | `autodiscover.ignore_paths` on targeted `-d` | **Active** via `autodiscovery/ignored` negative case |
-| v0.45.0 | OpenTofu distribution detection | **Active** via `detection/opentofu-basic` |
-| v0.45.0 | `.tf`, `.tf.json`, `terragrunt.hcl` detection | **Active** (`.tf`, `.tf.json`); Terragrunt deferred (not in CI) |
-| v0.45.0 | Path-hardening (CWE-22) | **Active** negative case in E2E runner |
+| v0.45.0 | `autodiscover.ignore_paths` on targeted `-d` | Fixture only; requires companion runner change |
+| v0.45.0 | OpenTofu distribution detection | Fixture only; requires companion runner change |
+| v0.45.0 | `.tf`, `.tf.json`, `terragrunt.hcl` detection | Fixture only (`.tf`, `.tf.json`); Terragrunt deferred (not in CI) |
+| v0.45.0 | Path-hardening (CWE-22) | Follow-up — requires companion runner negative test case |
 | v0.45.0 | Slack payload improvements | Follow-up — needs mock HTTP receiver |
-| v0.45.0 | Streamed failure text to job page | **Active** via `output/failure` |
+| v0.45.0 | Streamed failure text to job page | Fixture only; requires companion runner change |
 | v0.44.1 | Apply lock fail-closed | Follow-up — needs Redis/lock backend in CI |
-| v0.44.1 | No-change apply status (`up to date`) | **Active** via apply-after-plan E2E case |
-| v0.44.1 | Stale `.tfplan` cleanup | Covered by branch-update E2E case design |
-| v0.44.1 | Heredoc/multiline diff rendering | Fixture only — visual, hard to assert |
+| v0.44.1 | No-change apply status (`up to date`) | Follow-up — requires apply verification in runner |
+| v0.44.1 | Stale `.tfplan` cleanup | Follow-up — requires branch-update scenario in runner |
+| v0.44.1 | Heredoc/multiline diff rendering | Fixture only — visual, hard to assert programmatically |
 | v0.44.1 | `to forget` plan statistics | Fixture only — needs stateful resource |
-| v0.44.1 | Long line (>64KiB) output | Fixture only |
+| v0.44.1 | Long line (>64 KiB) output | Fixture only |
 | v0.44.0 | Sticky policy approvals | Follow-up — needs policy server config |
 | v0.44.0 | Redis cluster support | Follow-up — needs Redis in CI |
-| v0.44.0 | `PROJECT_NAME` hook env | **Active** via `custom-workflows/project-name-env` |
+| v0.44.0 | `PROJECT_NAME` hook env | Fixture only; requires companion runner change |
 
-## E2E Architecture
+## Current E2E Runner Architecture
 
-The E2E runner (`runatlantis/atlantis/e2e/main.go`) uses a test-case table:
+The current Atlantis E2E runner (`runatlantis/atlantis/e2e/main.go`) has two hardcoded test cases:
 
 ```go
-var projectTypes = []TestCase{...}
+var projectTypes = []Project{
+    {"standalone", "atlantis apply -d standalone"},
+    {"standalone-with-workspace", "atlantis apply -d standalone-with-workspace -w staging"},
+}
 ```
 
-Each test case specifies:
-- Name, Dir, Workspace, ProjectName
-- Files to mutate
-- Expected plan/apply status
-- Optional comment substring assertions
-- Whether failure is expected
-- VCS applicability (GitHub, GitLab, both)
+Each test: clones repo → creates branch → writes `.tf` file → pushes → creates PR → polls `atlantis/plan` commit status until success/failure/timeout → cleans up.
+
+**Limitations of current runner:**
+- Only checks plan status, never issues apply
+- No comment text assertion
+- No project-name targeting (`-p`)
+- No negative/failure test cases
+- No autodiscovery or custom workflow verification
+
+## Companion Runner Changes Needed (`runatlantis/atlantis`)
+
+To activate the new fixtures, the runner needs:
+
+1. Richer test-case table with: Name, Dir, Workspace, ProjectName, FilesToMutate, ExpectedStatus, ApplyCommand, ExpectedCommentSubstring, ExpectFailure, VCS
+2. New test cases for each fixture category
+3. Apply verification (issue apply, check status)
+4. Comment assertion (fetch PR comments, match substrings)
+5. Negative test cases (expected failures, ignored paths)
 
 ## Follow-up Items (Cannot Be Covered by Fixtures Alone)
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,73 @@
+# Atlantis E2E Coverage Inventory
+
+## Current Fixtures
+
+| Fixture | Atlantis Feature | Release Motivation | Active E2E? | Notes |
+|---------|-----------------|-------------------|-------------|-------|
+| `standalone` | Basic single-project plan/apply | Original smoke test | Yes (plan only) | No apply verification |
+| `standalone-with-workspace` | Workspace-based planning | Original smoke test | Yes (plan only) | workspace=staging |
+| `multi-projects/project1` | Explicit multi-project config | General coverage | **Yes** | `-p project1` targeting |
+| `multi-projects/project2` | Explicit multi-project config | General coverage | **Yes** | `-p project2` targeting |
+| `multi-projects/project-with-workspace` | Project + workspace combo | General coverage | **Yes** | workspace=dev |
+| `multi-projects/shared-module` | `when_modified` fan-out | General coverage | Fixture only | Needs E2E case that modifies shared module |
+| `autodiscovery/included-a` | Autodiscovery mode:enabled | v0.45.0 #6466 | **Yes** | Auto-discovered, not in explicit projects |
+| `autodiscovery/included-b` | Autodiscovery mode:enabled | v0.45.0 #6466 | Fixture only | Second auto-discovered project |
+| `autodiscovery/ignored` | `autodiscover.ignore_paths` | v0.45.0 #6466 | **Yes** (negative) | Targeted `-d` should respect ignore |
+| `autodiscovery/explicit` | Explicit overrides discovery | v0.45.0 #6466 | **Yes** | Explicit project takes precedence |
+| `detection/terraform-tf` | `.tf` file detection | v0.44.1 #6455 | **Yes** | Standard terraform project |
+| `detection/terraform-json` | `.tf.json` detection | v0.44.1 #6455 | **Yes** | JSON-format terraform |
+| `detection/opentofu-basic` | OpenTofu distribution | v0.45.0 #6597 | **Yes** | `terraform_distribution: opentofu` |
+| `custom-workflows/project-name-env` | PROJECT_NAME in hooks | v0.44.0 #6438 | **Yes** | Custom workflow asserts env var |
+| `output/heredoc` | Heredoc/multiline diffs | v0.44.1 #6561 | Fixture only | Plan output rendering |
+| `output/long-line` | Long single-line output | v0.44.1 #6544 | Fixture only | 64KiB+ line preservation |
+| `output/failure` | Failure text on job page | v0.45.0 #6414 | **Yes** (negative) | Intentional failure with marker |
+| `drift/local-file` | Drift detection API scaffold | v0.45.0 #6360 | TODO | Needs `--enable-drift-detection` |
+
+## Release Coverage Matrix
+
+| Release | Feature/Fix | Coverage Status |
+|---------|------------|----------------|
+| v0.45.0 | Drift detection/remediation APIs | Fixture scaffold only — needs dedicated E2E mode with `--enable-drift-detection` |
+| v0.45.0 | Localization (`--language`) | Follow-up — requires server-side config, not repo-level |
+| v0.45.0 | Automerge controls | Follow-up — risky in live test repo, needs isolated fork |
+| v0.45.0 | `autodiscover.ignore_paths` on targeted `-d` | **Active** via `autodiscovery/ignored` negative case |
+| v0.45.0 | OpenTofu distribution detection | **Active** via `detection/opentofu-basic` |
+| v0.45.0 | `.tf`, `.tf.json`, `terragrunt.hcl` detection | **Active** (`.tf`, `.tf.json`); Terragrunt deferred (not in CI) |
+| v0.45.0 | Path-hardening (CWE-22) | **Active** negative case in E2E runner |
+| v0.45.0 | Slack payload improvements | Follow-up — needs mock HTTP receiver |
+| v0.45.0 | Streamed failure text to job page | **Active** via `output/failure` |
+| v0.44.1 | Apply lock fail-closed | Follow-up — needs Redis/lock backend in CI |
+| v0.44.1 | No-change apply status (`up to date`) | **Active** via apply-after-plan E2E case |
+| v0.44.1 | Stale `.tfplan` cleanup | Covered by branch-update E2E case design |
+| v0.44.1 | Heredoc/multiline diff rendering | Fixture only — visual, hard to assert |
+| v0.44.1 | `to forget` plan statistics | Fixture only — needs stateful resource |
+| v0.44.1 | Long line (>64KiB) output | Fixture only |
+| v0.44.0 | Sticky policy approvals | Follow-up — needs policy server config |
+| v0.44.0 | Redis cluster support | Follow-up — needs Redis in CI |
+| v0.44.0 | `PROJECT_NAME` hook env | **Active** via `custom-workflows/project-name-env` |
+
+## E2E Architecture
+
+The E2E runner (`runatlantis/atlantis/e2e/main.go`) uses a test-case table:
+
+```go
+var projectTypes = []TestCase{...}
+```
+
+Each test case specifies:
+- Name, Dir, Workspace, ProjectName
+- Files to mutate
+- Expected plan/apply status
+- Optional comment substring assertions
+- Whether failure is expected
+- VCS applicability (GitHub, GitLab, both)
+
+## Follow-up Items (Cannot Be Covered by Fixtures Alone)
+
+1. **Localization** — needs `--language`/`--language-config-file` server flag
+2. **Automerge** — needs isolated fork to safely merge test PRs
+3. **Redis cluster locking** — needs Redis service in CI
+4. **Slack notifications** — needs mock HTTP receiver
+5. **GitHub App checkout** — needs App credentials with fork access
+6. **Sticky policy approvals** — needs conftest/policy server
+7. **Drift API full cycle** — needs `--enable-drift-detection` and local state mutation

--- a/drift/README.md
+++ b/drift/README.md
@@ -1,0 +1,23 @@
+# Drift Detection Fixture (Scaffold)
+
+Alpha drift detection/remediation API scaffolding (v0.45.0 #6360).
+
+## Status: TODO
+
+This fixture provides the Terraform configuration but does NOT have active E2E coverage yet.
+
+## Requirements for Active Coverage
+
+1. Atlantis must be started with `--enable-drift-detection`
+2. E2E must plan/apply the `local_file` resource to create initial state
+3. E2E must externally modify `drift-target.txt` to induce drift
+4. E2E must call drift detection API with `X-Atlantis-Token`
+5. E2E must verify auth failures without token
+6. E2E must verify path/repo validation rejects invalid inputs
+
+## Design Notes
+
+- Uses `local_file` provider (no cloud credentials needed)
+- Drift can be induced by writing directly to `drift-target.txt` after apply
+- Remediation apply should only work when `has_drift: true` is cached
+- Do NOT enable `--enable-drift-remediation` in generic E2E

--- a/drift/local-file/main.tf
+++ b/drift/local-file/main.tf
@@ -1,0 +1,8 @@
+resource "local_file" "drift_target" {
+  content  = "initial-content-for-drift-detection"
+  filename = "${path.module}/drift-target.txt"
+}
+
+output "drift_marker" {
+  value = "drift-detection-scaffold"
+}

--- a/multi-projects/README.md
+++ b/multi-projects/README.md
@@ -1,0 +1,25 @@
+# Multi-Projects Fixture
+
+Tests Atlantis explicit multi-project configuration.
+
+## Coverage
+
+- **Project targeting**: `atlantis plan -p project1`, `atlantis apply -p project2`
+- **when_modified fan-out**: Changes to `shared-module/` trigger plans for both project1 and project2
+- **Project + workspace**: `project-with-workspace` uses workspace=dev
+- **Isolation**: Changing project1 should NOT plan project2 (unless shared-module changes)
+
+## Projects
+
+| Dir | Project Name | Workspace | Notes |
+|-----|-------------|-----------|-------|
+| `project1/` | project1 | default | Depends on shared-module via when_modified |
+| `project2/` | project2 | default | Depends on shared-module via when_modified |
+| `project-with-workspace/` | project-with-workspace | dev | Tests workspace + project name combo |
+| `shared-module/` | — | — | Not a project; triggers fan-out when modified |
+
+## E2E Behavior
+
+1. Modify `project1/main.tf` → only project1 plans
+2. Modify `shared-module/main.tf` → both project1 and project2 plan
+3. `atlantis apply -p project1` → applies only project1

--- a/multi-projects/project-with-workspace/main.tf
+++ b/multi-projects/project-with-workspace/main.tf
@@ -1,0 +1,14 @@
+variable "environment" {
+  default = "dev"
+}
+
+resource "null_resource" "workspace_project" {
+  triggers = {
+    env    = var.environment
+    marker = "atlantis-e2e-workspace-${var.environment}"
+  }
+}
+
+output "workspace_marker" {
+  value = "workspace-${var.environment}-planned"
+}

--- a/multi-projects/project1/main.tf
+++ b/multi-projects/project1/main.tf
@@ -1,2 +1,9 @@
-resource "null_resource" "example" {
+resource "null_resource" "project1" {
+  triggers = {
+    marker = "atlantis-e2e-project1"
+  }
+}
+
+output "project1_marker" {
+  value = "project1-planned"
 }

--- a/multi-projects/project2/main.tf
+++ b/multi-projects/project2/main.tf
@@ -1,2 +1,9 @@
-resource "null_resource" "example" {
+resource "null_resource" "project2" {
+  triggers = {
+    marker = "atlantis-e2e-project2"
+  }
+}
+
+output "project2_marker" {
+  value = "project2-planned"
 }

--- a/multi-projects/shared-module/main.tf
+++ b/multi-projects/shared-module/main.tf
@@ -1,0 +1,8 @@
+variable "caller" {
+  type    = string
+  default = "unknown"
+}
+
+output "shared_value" {
+  value = "shared-module-output-for-${var.caller}"
+}

--- a/output/README.md
+++ b/output/README.md
@@ -10,15 +10,15 @@ Tests Terraform plan output rendering in Atlantis comments and job page.
 
 ## Projects
 
-| Dir | Behavior | Active E2E |
-|-----|----------|------------|
+| Dir | Behavior | Current Status |
+|-----|----------|----------------|
 | `heredoc/` | Generates multiline plan diff | Fixture only |
-| `long-line/` | Generates very long output line | Fixture only |
-| `failure/` | Intentionally fails with ATLANTIS_E2E_FAILURE_MARKER | Yes (negative test) |
+| `long-line/` | Generates ~80 KiB single-line output | Fixture only |
+| `failure/` | Intentionally fails with ATLANTIS_E2E_FAILURE_MARKER | Fixture only; requires companion runner support |
 
 ## Notes
 
 - `failure/` has `autoplan.enabled: false` — only triggered by targeted command
 - `failure/` uses workflow `intentional-failure` that echoes a marker then exits 1
-- E2E asserts the marker string appears in the failure output/comment
+- A companion runner can trigger this fixture explicitly and assert the stable marker string appears in failure output/comment, but the current upstream runner does not execute it
 - `heredoc/` and `long-line/` use `terraform_data` (requires Terraform 1.4+)

--- a/output/README.md
+++ b/output/README.md
@@ -1,0 +1,24 @@
+# Output Rendering Fixture
+
+Tests Terraform plan output rendering in Atlantis comments and job page.
+
+## Coverage
+
+- **Heredoc/multiline diffs** (v0.44.1 #6561): Multi-line string with special chars
+- **Long single-line output** (v0.44.1 #6544): String exceeding 64KiB
+- **Failure text on job page** (v0.45.0 #6414): Intentional failure with unique marker
+
+## Projects
+
+| Dir | Behavior | Active E2E |
+|-----|----------|------------|
+| `heredoc/` | Generates multiline plan diff | Fixture only |
+| `long-line/` | Generates very long output line | Fixture only |
+| `failure/` | Intentionally fails with ATLANTIS_E2E_FAILURE_MARKER | Yes (negative test) |
+
+## Notes
+
+- `failure/` has `autoplan.enabled: false` — only triggered by targeted command
+- `failure/` uses workflow `intentional-failure` that echoes a marker then exits 1
+- E2E asserts the marker string appears in the failure output/comment
+- `heredoc/` and `long-line/` use `terraform_data` (requires Terraform 1.4+)

--- a/output/failure/main.tf
+++ b/output/failure/main.tf
@@ -1,0 +1,9 @@
+resource "null_resource" "failure_test" {
+  triggers = {
+    marker = "atlantis-e2e-failure-output"
+  }
+}
+
+output "failure_marker" {
+  value = "FAILURE_MARKER_E2E_TEST"
+}

--- a/output/heredoc/main.tf
+++ b/output/heredoc/main.tf
@@ -1,0 +1,13 @@
+resource "terraform_data" "heredoc_output" {
+  input = <<-EOT
+    This is a multiline heredoc string
+    used to test plan output rendering.
+    Line 3 with special chars: "quotes" & <brackets>
+    Line 4 with trailing spaces
+    Line 5 final line
+  EOT
+}
+
+output "heredoc_marker" {
+  value = "heredoc-output-test"
+}

--- a/output/long-line/main.tf
+++ b/output/long-line/main.tf
@@ -1,7 +1,9 @@
-# Generates a single-line string >64 KiB (~84 KB) to exercise the plan output
-# scanner boundary fix from v0.44.1 #6544.
+# Exercises the plan output scanner boundary fix from v0.44.1 #6544.
+# Generates a single-line string >64 KiB (~88 KiB).
+# Uses range(1000) (Terraform caps range() at 1024 elements) with ~90 bytes
+# per element to exceed the 64 KiB threshold.
 locals {
-  long_string = join("", [for i in range(2000) : "abcdefghijklmnopqrstuvwxyz0123456789-${i}-"])
+  long_string = join("", [for i in range(1000) : "abcdefghijklmnopqrstuvwxyz0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ-padding-extra-${i}-"])
 }
 
 resource "terraform_data" "long_line_output" {

--- a/output/long-line/main.tf
+++ b/output/long-line/main.tf
@@ -1,0 +1,11 @@
+locals {
+  long_string = join("", [for i in range(1000) : "abcdefghijklmnopqrstuvwxyz0123456789-${i}-"])
+}
+
+resource "terraform_data" "long_line_output" {
+  input = local.long_string
+}
+
+output "long_line_marker" {
+  value = "long-line-output-test"
+}

--- a/output/long-line/main.tf
+++ b/output/long-line/main.tf
@@ -1,5 +1,7 @@
+# Generates a single-line string >64 KiB (~84 KB) to exercise the plan output
+# scanner boundary fix from v0.44.1 #6544.
 locals {
-  long_string = join("", [for i in range(1000) : "abcdefghijklmnopqrstuvwxyz0123456789-${i}-"])
+  long_string = join("", [for i in range(2000) : "abcdefghijklmnopqrstuvwxyz0123456789-${i}-"])
 }
 
 resource "terraform_data" "long_line_output" {


### PR DESCRIPTION
## Summary

Expands `atlantis-tests` from a minimal 2-project smoke-test repo into a broader integration harness covering major Atlantis user workflows and recent release changes.

## What Changed

### Root `atlantis.yaml`
- Expanded from 2-project one-liner to full multi-line config with 13 explicit projects
- Added `autodiscover.mode: enabled` with `ignore_paths`
- Added custom workflow definitions (`assert-project-name`, `intentional-failure`)
- Existing `standalone` and `standalone-with-workspace` entries preserved exactly

### New Fixture Categories

| Category | Projects | Release Coverage |
|----------|----------|-----------------|
| `multi-projects/` | project1, project2, project-with-workspace, shared-module | General multi-project, `-p` targeting, `when_modified` fan-out |
| `autodiscovery/` | included-a, included-b, ignored, explicit | v0.45.0 #6466 — `ignore_paths` on targeted `-d` |
| `detection/` | terraform-tf, terraform-json, opentofu-basic | v0.44.1 #6455, v0.45.0 #6597 |
| `custom-workflows/` | project-name-env + assert script | v0.44.0 #6438 — `PROJECT_NAME` env |
| `output/` | heredoc, long-line, failure | v0.44.1 #6561/#6544, v0.45.0 #6414 |
| `drift/` | local-file scaffold | v0.45.0 #6360 (alpha, TODO) |

### Documentation
- `docs/coverage.md` — full coverage matrix with release mapping and follow-up items
- Per-category `README.md` files explaining coverage, E2E behavior, and design
- Updated root `README.md` with fixture table and contribution guide

## Backward Compatibility

- `standalone` and `standalone-with-workspace` paths unchanged
- Existing E2E tests (`atlantis plan -d standalone`, `atlantis apply -d standalone-with-workspace -w staging`) remain green
- No provider downloads beyond `null`, `terraform_data`, `local_file`

## Companion Changes Needed (separate PR to `runatlantis/atlantis`)

The current E2E runner (`e2e/main.go`) only exercises 2 projects. To actively cover the new fixtures, the runner needs:

1. **Richer test-case table** with fields: Name, Dir, Workspace, ProjectName, FilesToMutate, ExpectedStatus, ApplyCommand, ExpectedCommentSubstring, ExpectFailure, VCS
2. **New test cases** for: multi-project targeting, autodiscovery, OpenTofu detection, custom workflow, failure output, path-traversal negative case
3. **Apply verification** — issue apply command and check apply status
4. **Comment assertion** — fetch PR comments and match expected substrings

## Items That Remain Follow-Up

- Localization (`--language`) — server config, not repo-level
- Automerge controls — risky in live test repo
- Redis cluster locking — needs Redis in CI
- Slack notifications — needs mock HTTP receiver
- Drift API full cycle — needs `--enable-drift-detection`
- Sticky policy approvals — needs conftest/policy server

## Validation

- `terraform fmt -recursive` — clean
- All HCL is deterministic, no cloud credentials required