### PR TITLE
test: add on_apply lock preservation fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Integration test fixture repository for [Atlantis](https://github.com/runatlanti
 | `detection/` | `.tf`, `.tf.json`, OpenTofu distribution detection | Fixture only; requires companion runner change |
 | `custom-workflows/` | Custom workflows, `PROJECT_NAME` hook env | Fixture only; requires companion runner change |
 | `output/` | Plan output rendering (heredoc, long-line, failure text) | Fixture only |
-| `locking/` | Repo lock lifecycle fixtures, including `repo_locks.mode: on_apply` preservation | Fixture only; requires companion runner change |
+| `locking/` | Repo lock lifecycle fixtures, including future `repo_locks.mode: on_apply` preservation coverage | Fixture only; requires companion runner/server config change |
 | `drift/` | Drift detection API scaffolding (alpha) | Scaffold only |
 
 ## How E2E Works

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Integration test fixture repository for [Atlantis](https://github.com/runatlanti
 | `detection/` | `.tf`, `.tf.json`, OpenTofu distribution detection | Fixture only; requires companion runner change |
 | `custom-workflows/` | Custom workflows, `PROJECT_NAME` hook env | Fixture only; requires companion runner change |
 | `output/` | Plan output rendering (heredoc, long-line, failure text) | Fixture only |
+| `locking/` | Repo lock lifecycle fixtures, including `repo_locks.mode: on_apply` preservation | Fixture only; requires companion runner change |
 | `drift/` | Drift detection API scaffolding (alpha) | Scaffold only |
 
 ## How E2E Works

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -75,6 +75,13 @@ projects:
     autoplan:
       enabled: false
 
+  # --- Locking lifecycle fixtures ---
+  - dir: locking/on-apply-lock-preservation
+    name: locking-on-apply-preservation
+    workspace: default
+    repo_locks:
+      mode: on_apply
+
 workflows:
   assert-project-name:
     plan:

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -79,8 +79,9 @@ projects:
   - dir: locking/on-apply-lock-preservation
     name: locking-on-apply-preservation
     workspace: default
-    repo_locks:
-      mode: on_apply
+    # NOTE: The future #6531 runner scenario must run this project with
+    # repo_locks.mode: on_apply. Do not set repo_locks here until the
+    # upstream E2E server allows repo_locks as a repo-side override.
 
 workflows:
   assert-project-name:

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -26,6 +26,7 @@
 | `output/heredoc` | Heredoc/multiline diffs | v0.44.1 #6561 | Fixture only | Plan output rendering |
 | `output/long-line` | Long single-line output (>64 KiB) | v0.44.1 #6544 | Fixture only | ~88 KiB single-line value |
 | `output/failure` | Failure text on job page | v0.45.0 #6414 | Fixture only; requires companion runner change | Intentional failure with marker |
+| `locking/on-apply-lock-preservation` | `repo_locks.mode: on_apply` apply-lock preservation | PR #6606 / issue #6531 | Fixture only; requires companion runner change | Needs apply command plus two-PR lock contention scenario |
 | `drift/local-file` | Drift detection API scaffold | v0.45.0 #6360 | Scaffold only | Needs `--enable-drift-detection` server flag |
 
 ## Release Coverage Matrix
@@ -41,6 +42,7 @@
 | v0.45.0 | Path-hardening (CWE-22) | Follow-up — requires companion runner negative test case |
 | v0.45.0 | Slack payload improvements | Follow-up — needs mock HTTP receiver |
 | v0.45.0 | Streamed failure text to job page | Fixture only; requires companion runner change |
+| unreleased / next Atlantis | `repo_locks.mode: on_apply` plan cleanup must not delete apply-created locks (#6531 / #6606) | Fixture only — requires apply verification and two-PR lock lifecycle runner support |
 | v0.44.1 | Apply lock fail-closed | Follow-up — needs Redis/lock backend in CI |
 | v0.44.1 | No-change apply status (`up to date`) | Follow-up — requires apply verification in runner |
 | v0.44.1 | Stale `.tfplan` cleanup | Follow-up — requires branch-update scenario in runner |
@@ -80,6 +82,7 @@ To activate the new fixtures, the runner needs:
 3. Apply verification (issue apply, check status)
 4. Comment assertion (fetch PR comments, match substrings)
 5. Negative test cases (expected failures, ignored paths)
+6. `repo_locks.mode: on_apply` preservation — needs runner support to issue `atlantis apply`, trigger a later generic/autoplan cleanup on the same PR, open a second PR against the same project, and assert the second PR remains blocked by the first PR's apply-created lock.
 
 ## Follow-up Items (Cannot Be Covered by Fixtures Alone)
 
@@ -90,3 +93,11 @@ To activate the new fixtures, the runner needs:
 5. **GitHub App checkout** — needs App credentials with fork access
 6. **Sticky policy approvals** — needs conftest/policy server
 7. **Drift API full cycle** — needs `--enable-drift-detection` and local state mutation
+8. **`repo_locks.mode: on_apply` preservation** — future runner scenario:
+   1. PR1 changes `locking/on-apply-lock-preservation`.
+   2. Wait for plan success.
+   3. Comment `atlantis apply`.
+   4. Confirm apply success.
+   5. Trigger later generic `atlantis plan` or autoplan on PR1.
+   6. Open PR2 touching the same fixture.
+   7. Confirm PR2 apply is blocked by PR1's apply-created lock.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -26,8 +26,22 @@
 | `output/heredoc` | Heredoc/multiline diffs | v0.44.1 #6561 | Fixture only | Plan output rendering |
 | `output/long-line` | Long single-line output (>64 KiB) | v0.44.1 #6544 | Fixture only | ~88 KiB single-line value |
 | `output/failure` | Failure text on job page | v0.45.0 #6414 | Fixture only; requires companion runner change | Intentional failure with marker |
-| `locking/on-apply-lock-preservation` | `repo_locks.mode: on_apply` apply-lock preservation | PR #6606 / issue #6531 | Fixture only; requires companion runner change | Needs apply command plus two-PR lock contention scenario |
+| `locking/on-apply-lock-preservation` | `repo_locks.mode: on_apply` apply-lock preservation | PR #6606 / issue #6531 | Fixture only; requires companion runner/server config change | Root config intentionally omits active `repo_locks`; needs allowed override or server-side locking plus apply/two-PR lock contention scenario |
 | `drift/local-file` | Drift detection API scaffold | v0.45.0 #6360 | Scaffold only | Needs `--enable-drift-detection` server flag |
+
+### Locking Fixture Activation
+
+Future runner activation must either allow `repo_locks` as a repo-side override or configure equivalent server-side locking. The intended project config is:
+
+```yaml
+- dir: locking/on-apply-lock-preservation
+  name: locking-on-apply-preservation
+  workspace: default
+  repo_locks:
+    mode: on_apply
+```
+
+The current fixture PR intentionally does not set `repo_locks` in the shared root `atlantis.yaml` because today's upstream E2E server does not allow that repo-side override.
 
 ## Release Coverage Matrix
 
@@ -42,7 +56,7 @@
 | v0.45.0 | Path-hardening (CWE-22) | Follow-up — requires companion runner negative test case |
 | v0.45.0 | Slack payload improvements | Follow-up — needs mock HTTP receiver |
 | v0.45.0 | Streamed failure text to job page | Fixture only; requires companion runner change |
-| unreleased / next Atlantis | `repo_locks.mode: on_apply` plan cleanup must not delete apply-created locks (#6531 / #6606) | Fixture only — requires apply verification and two-PR lock lifecycle runner support |
+| unreleased / next Atlantis | `repo_locks.mode: on_apply` plan cleanup must not delete apply-created locks (#6531 / #6606) | Fixture only — requires `repo_locks` override allowance or server-side locking, apply verification, and two-PR lock lifecycle runner support |
 | v0.44.1 | Apply lock fail-closed | Follow-up — needs Redis/lock backend in CI |
 | v0.44.1 | No-change apply status (`up to date`) | Follow-up — requires apply verification in runner |
 | v0.44.1 | Stale `.tfplan` cleanup | Follow-up — requires branch-update scenario in runner |
@@ -82,7 +96,12 @@ To activate the new fixtures, the runner needs:
 3. Apply verification (issue apply, check status)
 4. Comment assertion (fetch PR comments, match substrings)
 5. Negative test cases (expected failures, ignored paths)
-6. `repo_locks.mode: on_apply` preservation — needs runner support to issue `atlantis apply`, trigger a later generic/autoplan cleanup on the same PR, open a second PR against the same project, and assert the second PR remains blocked by the first PR's apply-created lock.
+6. `repo_locks.mode: on_apply` preservation — needs runner support to:
+   1. allow `repo_locks` as a repo-side override, or configure `on_apply` locking server-side;
+   2. issue `atlantis apply`;
+   3. trigger a later generic/autoplan cleanup on the same PR;
+   4. open a second PR against the same project;
+   5. assert the second PR remains blocked by the first PR's apply-created lock.
 
 ## Follow-up Items (Cannot Be Covered by Fixtures Alone)
 
@@ -94,10 +113,11 @@ To activate the new fixtures, the runner needs:
 6. **Sticky policy approvals** — needs conftest/policy server
 7. **Drift API full cycle** — needs `--enable-drift-detection` and local state mutation
 8. **`repo_locks.mode: on_apply` preservation** — future runner scenario:
-   1. PR1 changes `locking/on-apply-lock-preservation`.
-   2. Wait for plan success.
-   3. Comment `atlantis apply`.
-   4. Confirm apply success.
-   5. Trigger later generic `atlantis plan` or autoplan on PR1.
-   6. Open PR2 touching the same fixture.
-   7. Confirm PR2 apply is blocked by PR1's apply-created lock.
+   1. Allow `repo_locks` as a repo-side override, or configure `on_apply` locking server-side.
+   2. PR1 changes `locking/on-apply-lock-preservation`.
+   3. Wait for plan success.
+   4. Comment `atlantis apply`.
+   5. Confirm apply success.
+   6. Trigger later generic `atlantis plan` or autoplan on PR1.
+   7. Open PR2 touching the same fixture.
+   8. Confirm PR2 apply is blocked by PR1's apply-created lock.

--- a/locking/on-apply-lock-preservation/main.tf
+++ b/locking/on-apply-lock-preservation/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.5.0"
+}
+
+resource "terraform_data" "on_apply_lock_preservation" {
+  input = "on-apply-lock-preservation"
+}
+
+output "on_apply_lock_preservation_marker" {
+  value = terraform_data.on_apply_lock_preservation.output
+}


### PR DESCRIPTION
## What changed

Adds a fixture for `repo_locks.mode: on_apply` lock preservation, related to runatlantis/atlantis#6531 and runatlantis/atlantis#6606.

The fixture is intentionally marked as fixture-only because the current upstream Atlantis E2E runner does not yet issue `atlantis apply` or exercise two-PR lock lifecycle scenarios.

Note: this PR intentionally keeps the shared root `atlantis.yaml` parseable under today's E2E server config. The future runner activation must allow `repo_locks` as a repo-side override, or configure equivalent server-side `on_apply` locking, before exercising this fixture.

## Why

The Atlantis fix ensures later plan cleanup does not delete apply-created locks when `repo_locks.mode: on_apply` is used. A future runner enhancement can use this fixture to verify that:

1. PR1 plans and applies the project.
2. PR1 keeps the apply-created lock.
3. A later plan/autoplan on PR1 does not remove that lock.
4. PR2 remains blocked from applying the same project.

## Validation

- Inspected fixture/config/docs references.
- Confirmed the fixture is documented as requiring a companion runner/server config change.
- Confirmed the shared root `atlantis.yaml` does not parse with an active `repo_locks` key for this fixture.
- Ran `terraform fmt -check -recursive`.
- Parsed `atlantis.yaml` with `yq`.
- Ran `git diff --check`.

## Follow-up

A companion `runatlantis/atlantis` E2E runner change is needed to allow `repo_locks` as a repo-side override or configure `on_apply` locking server-side, then actively exercise apply commands, two concurrent PRs, and lock-conflict assertions.
