### PR TITLE
test: expand plan generation and replan regression fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ GitHub or GitLab E2E jobs; opt-in cases require `E2E_OPT_IN=1`.
 |-----------|---------|----------------|
 | `standalone/` | Basic single-project plan | Active on GitHub and GitLab |
 | `standalone-with-workspace/` | Workspace-based planning | Active on GitHub |
-| `apply-regressions/` | Built-in autoplan followed immediately by targeted apply | Active plan-then-apply on GitHub |
+| `apply-regressions/` | Immediate apply, built-in replan, and managed-plan mutation regressions | Active success and expected-failure lifecycles on GitHub |
 | `multi-projects/` | Explicit projects and `when_modified` fan-out | Active project/fan-out cases; workspace case opt-in |
 | `autodiscovery/` | Autodiscovery and explicit precedence | Included project active; explicit precedence opt-in |
 | `detection/` | `.tf`, `.tf.json`, OpenTofu detection | `.tf.json` active; OpenTofu disabled; others fixture-only |
-| `custom-workflows/` | Hook environment and user-managed plan paths | Both regression workflows active on GitHub |
+| `custom-workflows/` | Hook environment and user-managed plan paths | Custom path and custom replan lifecycles active on GitHub |
 | `output/` | Plan output rendering | Long-line active; failure disabled; heredoc fixture-only |
 | `locking/` | `repo_locks.mode: on_apply` preservation | Opt-in two-PR plan/apply lifecycle |
 | `drift/` | Drift detection API scaffolding | Disabled until the server flag is available in E2E |
@@ -29,8 +29,9 @@ GitHub or GitLab E2E jobs; opt-in cases require `E2E_OPT_IN=1`.
 2. For each test case: clones repo → creates branch → mutates a Terraform file → pushes → opens PR
 3. Atlantis auto-plans via webhook
 4. Runner polls a new `atlantis/plan` result and asserts configured project statuses/comments
-5. Plan-then-apply cases post a targeted apply, reject stale status results, and assert a new apply comment marker
-6. Cleanup closes the PR, deletes the branch, and deletes the webhook
+5. Replan cases push a second generation, require a new plan result/comment, and only then post targeted apply
+6. Apply cases reject stale status results and assert either a new success marker or the configured failure evidence
+7. Cleanup closes the PR, deletes the branch, and deletes the webhook
 
 ## Adding Fixtures
 
@@ -39,6 +40,8 @@ GitHub or GitLab E2E jobs; opt-in cases require `E2E_OPT_IN=1`.
 - Add unique output markers for E2E assertion (`output "xyz_marker" { value = "..." }`)
 - Add explicit project entry in root `atlantis.yaml`
 - Update `docs/coverage.md`
+- Run `scripts/validate-fixture-consistency.sh`; when developing both repositories,
+  pass the upstream `e2e/testcase.go` path to validate cross-repository references
 
 ## License
 

--- a/apply-regressions/README.md
+++ b/apply-regressions/README.md
@@ -4,8 +4,12 @@ These projects exercise plan-to-apply lifecycles that regressed in Atlantis v0.4
 
 - `builtin-autoplan-apply` covers [Atlantis #6641](https://github.com/runatlantis/atlantis/issues/6641). Its built-in autoplan must persist `PullStatus`
   before the upstream runner immediately comments `atlantis apply -p builtin-autoplan-apply`.
+- `builtin-replan-apply` requires a second built-in plan generation and proves the
+  targeted apply consumes generation 2.
+- `mixed-plan-mutation` deliberately changes the managed plan between a custom
+  pre-apply step and the built-in apply. It is an active expected-failure case.
 - `custom-workflows/custom-plan-path` covers [Atlantis #6642](https://github.com/runatlantis/atlantis/issues/6642). It is documented with the custom
   workflow fixtures because both stages consist entirely of user-authored `run` steps.
 
-Both cases are active in the upstream GitHub E2E runner. Neither case needs cloud
-credentials or an external backend.
+All cases are credential-free and have explicit upstream lifecycle status in
+`docs/coverage.md`.

--- a/apply-regressions/builtin-replan-apply/README.md
+++ b/apply-regressions/builtin-replan-apply/README.md
@@ -1,0 +1,18 @@
+# Built-in Replan to Apply
+
+This credential-free fixture protects the plan-generation lifecycle adjacent to
+[Atlantis #6641](https://github.com/runatlantis/atlantis/issues/6641) and
+[Atlantis #6642](https://github.com/runatlantis/atlantis/issues/6642).
+
+The upstream runner creates `generation.auto.tfvars` with generation 1, waits for
+autoplan, overwrites it with generation 2 in a second commit, waits for the new
+plan, and then targets:
+
+```text
+atlantis apply -p builtin-replan-apply
+```
+
+The apply comment must contain `ATLANTIS_E2E_BUILTIN_REPLAN_GENERATION_2`, proving
+that the second convention-managed plan—not the first generation—was applied.
+
+Status: active in the upstream GitHub plan-replan-apply scenario.

--- a/apply-regressions/builtin-replan-apply/main.tf
+++ b/apply-regressions/builtin-replan-apply/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.4.0"
+}
+
+variable "e2e_generation" {
+  description = "Identifies the plan generation exercised by the E2E lifecycle."
+  type        = string
+  default     = "fixture-baseline"
+}
+
+resource "terraform_data" "builtin_replan_apply" {
+  input = var.e2e_generation
+}
+
+output "atlantis_e2e_builtin_replan_generation" {
+  value = "ATLANTIS_E2E_BUILTIN_REPLAN_${terraform_data.builtin_replan_apply.output}"
+}

--- a/apply-regressions/mixed-plan-mutation/README.md
+++ b/apply-regressions/mixed-plan-mutation/README.md
@@ -1,0 +1,16 @@
+# Mixed Managed Plan Mutation
+
+Negative regression fixture for the plan-hash protection introduced by
+[Atlantis #6605](https://github.com/runatlantis/atlantis/pull/6605).
+
+The plan uses Atlantis's built-in convention-managed file. Its apply workflow
+first mutates `$PLANFILE`, then invokes the built-in `apply` step. Atlantis must
+reject the changed plan immediately before the built-in runner executes.
+
+Expected evidence:
+
+- aggregate apply failure;
+- an error containing `plan file changed`;
+- no `ATLANTIS_E2E_MIXED_BUILTIN_APPLY_MUST_NOT_RUN` marker.
+
+Status: active only through the upstream expected-apply-failure scenario.

--- a/apply-regressions/mixed-plan-mutation/main.tf
+++ b/apply-regressions/mixed-plan-mutation/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.4.0"
+}
+
+resource "terraform_data" "mixed_plan_mutation" {
+  input = "ATLANTIS_E2E_MIXED_PLAN_MUTATION"
+}
+
+output "atlantis_e2e_mixed_apply_success" {
+  value = "ATLANTIS_E2E_MIXED_BUILTIN_APPLY_MUST_NOT_RUN"
+}

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -66,9 +66,20 @@ projects:
   - dir: apply-regressions/builtin-autoplan-apply
     name: builtin-autoplan-apply
 
+  - dir: apply-regressions/builtin-replan-apply
+    name: builtin-replan-apply
+
+  - dir: apply-regressions/mixed-plan-mutation
+    name: mixed-plan-mutation
+    workflow: mixed-plan-mutation
+
   - dir: custom-workflows/custom-plan-path
     name: custom-plan-path
     workflow: custom-plan-path
+
+  - dir: custom-workflows/custom-plan-replan
+    name: custom-plan-replan
+    workflow: custom-plan-replan
 
   # --- Output rendering fixtures ---
   - dir: output/heredoc
@@ -116,3 +127,23 @@ workflows:
         - run: test -f custom-atlantis.tfplan
         - run: terraform apply -input=false -no-color custom-atlantis.tfplan
         - run: echo ATLANTIS_E2E_CUSTOM_PLAN_APPLY_OK
+
+  custom-plan-replan:
+    plan:
+      steps:
+        - run: terraform init -input=false -no-color
+        - run: terraform plan -input=false -no-color -out=custom-replan.tfplan
+        - run: test -f custom-replan.tfplan
+        - run: sh plan-generation-marker.sh
+    apply:
+      steps:
+        - run: test -f custom-replan.tfplan
+        - run: terraform apply -input=false -no-color custom-replan.tfplan
+        - run: echo ATLANTIS_E2E_CUSTOM_REPLAN_APPLY_OK
+
+  mixed-plan-mutation:
+    apply:
+      steps:
+        - run: printf '\nATLANTIS_E2E_MIXED_PLAN_MUTATED\n' >> "$PLANFILE"
+        - apply
+        - run: echo ATLANTIS_E2E_MIXED_BUILTIN_APPLY_MUST_NOT_RUN

--- a/custom-workflows/README.md
+++ b/custom-workflows/README.md
@@ -8,6 +8,7 @@ Tests custom workflow execution, hook environment variables, and user-managed pl
 - **Custom workflow steps**: `run` step executes before `init`/`plan`
 - **Script validation**: POSIX shell script with clear pass/fail output
 - **Custom plan path apply**: v0.46.0 regression coverage for Atlantis #6642
+- **Custom plan replan**: two generations at a user-managed path with targeted apply
 
 ## Workflow Definition (in root atlantis.yaml)
 
@@ -32,6 +33,19 @@ workflows:
         - run: test -f custom-atlantis.tfplan
         - run: terraform apply -input=false -no-color custom-atlantis.tfplan
         - run: echo ATLANTIS_E2E_CUSTOM_PLAN_APPLY_OK
+
+  custom-plan-replan:
+    plan:
+      steps:
+        - run: terraform init -input=false -no-color
+        - run: terraform plan -input=false -no-color -out=custom-replan.tfplan
+        - run: test -f custom-replan.tfplan
+        - run: sh plan-generation-marker.sh
+    apply:
+      steps:
+        - run: test -f custom-replan.tfplan
+        - run: terraform apply -input=false -no-color custom-replan.tfplan
+        - run: echo ATLANTIS_E2E_CUSTOM_REPLAN_APPLY_OK
 ```
 
 ## E2E Behavior
@@ -43,3 +57,7 @@ workflows:
 
 For `custom-plan-path`, the runner waits for the custom autoplan marker, posts
 `atlantis apply -p custom-plan-path`, and requires the apply marker from a new comment.
+
+For `custom-plan-replan`, the runner overwrites `generation.auto.tfvars`, requires
+the generation-2 plan marker in a new comment, and then applies the targeted custom
+plan path. Neither custom workflow creates Atlantis's convention plan file.

--- a/custom-workflows/custom-plan-replan/README.md
+++ b/custom-workflows/custom-plan-replan/README.md
@@ -1,0 +1,18 @@
+# Custom Plan Replan
+
+This fixture extends the run-only custom-plan-path regression coverage for
+[Atlantis #6642](https://github.com/runatlantis/atlantis/issues/6642).
+
+Both stages contain only `run` steps. Plans are written to
+`custom-replan.tfplan`; the workflow never references or creates `$PLANFILE`.
+Each plan prints an explicit generation marker from `generation.auto.tfvars`.
+The upstream runner plans generation 1, replans generation 2, and targets:
+
+```text
+atlantis apply -p custom-plan-replan
+```
+
+The apply must contain `ATLANTIS_E2E_CUSTOM_REPLAN_GENERATION_2` and
+`ATLANTIS_E2E_CUSTOM_REPLAN_APPLY_OK`.
+
+Status: active in the upstream GitHub plan-replan-apply scenario.

--- a/custom-workflows/custom-plan-replan/main.tf
+++ b/custom-workflows/custom-plan-replan/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.4.0"
+}
+
+variable "e2e_generation" {
+  description = "Identifies the custom plan generation exercised by E2E."
+  type        = string
+  default     = "fixture-baseline"
+}
+
+resource "terraform_data" "custom_plan_replan" {
+  input = var.e2e_generation
+}
+
+output "atlantis_e2e_custom_replan_generation" {
+  value = "ATLANTIS_E2E_CUSTOM_REPLAN_${terraform_data.custom_plan_replan.output}"
+}

--- a/custom-workflows/custom-plan-replan/plan-generation-marker.sh
+++ b/custom-workflows/custom-plan-replan/plan-generation-marker.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+generation=$(sed -n 's/^[[:space:]]*e2e_generation[[:space:]]*=[[:space:]]*"\([^"]*\)"[[:space:]]*$/\1/p' generation.auto.tfvars)
+if [ -z "$generation" ]; then
+  echo "missing e2e_generation in generation.auto.tfvars" >&2
+  exit 1
+fi
+
+echo "ATLANTIS_E2E_CUSTOM_REPLAN_PLAN_${generation}"

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,7 +1,9 @@
 # Atlantis E2E Coverage Inventory
 
 The upstream runner uses explicit lifecycle scenarios. `ScenarioPlanOnly` is the
-default, `ScenarioPlanThenApply` is active only for named apply cases, and
+default, `ScenarioPlanThenApply` is active only for named apply cases,
+`ScenarioPlanThenReplanThenApply` requires a second plan generation, and
+`ScenarioPlanThenApplyExpectFailure` protects negative apply cases. The
 `ScenarioOnApplyLockPreservation` is an opt-in two-PR lifecycle. An `ApplyCommand`
 on a plan-only case is intentionally not executed.
 
@@ -13,7 +15,10 @@ on a plan-only case is intentionally not executed.
 | `standalone` | Aggregate plan plus project comment marker | Active on GitLab |
 | `standalone-with-workspace` | Workspace `staging` plan | Active on GitHub |
 | `apply-regressions/builtin-autoplan-apply` | Built-in autoplan immediately followed by targeted built-in apply; Atlantis v0.46.0 regression [#6641](https://github.com/runatlantis/atlantis/issues/6641) | Active plan-then-apply on GitHub |
+| `apply-regressions/builtin-replan-apply` | Built-in generation 1, built-in generation 2, then targeted apply of generation 2 | Active plan-replan-apply on GitHub |
+| `apply-regressions/mixed-plan-mutation` | Custom pre-apply step mutates `$PLANFILE`; built-in apply must be rejected | Active expected-apply-failure on GitHub |
 | `custom-workflows/custom-plan-path` | Run-only plan/apply using `custom-atlantis.tfplan`, never `$PLANFILE`; Atlantis v0.46.0 regression [#6642](https://github.com/runatlantis/atlantis/issues/6642) | Active targeted plan-then-apply on GitHub |
+| `custom-workflows/custom-plan-replan` | Two run-only plan generations at `custom-replan.tfplan`, then targeted apply of generation 2 | Active plan-replan-apply on GitHub |
 | `multi-projects/project1` | Explicit project selection | Active on GitHub |
 | `multi-projects/shared-module` | `when_modified` fan-out to project1 and project2 | Active on GitHub |
 | `multi-projects/project-with-workspace` | Project plus workspace | Opt-in |
@@ -59,12 +64,26 @@ atlantis apply -p custom-plan-path
 It then requires a new successful aggregate/project apply result and a new comment
 containing `ATLANTIS_E2E_CUSTOM_PLAN_APPLY_OK`.
 
+### Built-in and custom replan to latest apply
+
+The two replan cases create `generation.auto.tfvars` with `GENERATION_1`, wait for
+the initial autoplan, replace it with `GENERATION_2` in a second commit, and reject
+the earlier terminal status/comment as stale. Targeted apply must expose the
+generation-2 output. The custom case never creates or references `$PLANFILE`.
+
+### Mixed managed-plan mutation
+
+The mixed workflow mutates the convention-managed plan before its built-in apply
+step. The runner requires a new aggregate apply failure containing `plan file changed`
+and rejects any comment containing `ATLANTIS_E2E_MIXED_BUILTIN_APPLY_MUST_NOT_RUN`.
+
 ## Runner Guarantees
 
 - Each lifecycle reuses the same clone, branch, mutation, push, pull-request, and cleanup setup.
 - Repeated commands are distinguished by commit-status ID or update time, so a stale aggregate status cannot satisfy apply.
 - GitHub cases can assert exact per-project plan and apply status contexts.
 - Apply comment markers must occur after the apply command; an older matching comment is rejected.
+- Replan markers must occur after the second push; the initial autoplan comment cannot satisfy them.
 - Timeout diagnostics include the pull-request URL, aggregate status, relevant project statuses, and recent Atlantis comments.
 
 ## Follow-up Coverage

--- a/scripts/validate-fixture-consistency.sh
+++ b/scripts/validate-fixture-consistency.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+config="$repo_root/atlantis.yaml"
+coverage="$repo_root/docs/coverage.md"
+tmp_dir=${TMPDIR:-/tmp}/atlantis-fixture-validation.$$
+trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+mkdir -p "$tmp_dir"
+
+awk '/^  - dir: / { print $3 }' "$config" >"$tmp_dir/dirs"
+while IFS= read -r dir; do
+  if [ ! -d "$repo_root/$dir" ]; then
+    echo "configured fixture directory does not exist: $dir" >&2
+    exit 1
+  fi
+done <"$tmp_dir/dirs"
+
+awk '/^    name: / { print $2 }' "$config" | sort >"$tmp_dir/names"
+duplicates=$(uniq -d "$tmp_dir/names")
+if [ -n "$duplicates" ]; then
+  echo "duplicate Atlantis project names:" >&2
+  echo "$duplicates" >&2
+  exit 1
+fi
+
+awk '
+  /^workflows:/ { in_workflows = 1; next }
+  !in_workflows && /^    workflow: / { print $2 }
+' "$config" | sort -u >"$tmp_dir/workflow-refs"
+awk '
+  /^workflows:/ { in_workflows = 1; next }
+  in_workflows && /^  [A-Za-z0-9_-]+:/ {
+    name = $1
+    sub(/:$/, "", name)
+    print name
+  }
+' "$config" | sort -u >"$tmp_dir/workflow-defs"
+while IFS= read -r workflow; do
+  if ! grep -Fxq "$workflow" "$tmp_dir/workflow-defs"; then
+    echo "project references undefined workflow: $workflow" >&2
+    exit 1
+  fi
+done <"$tmp_dir/workflow-refs"
+
+for fixture in \
+  apply-regressions/builtin-replan-apply \
+  apply-regressions/mixed-plan-mutation \
+  custom-workflows/custom-plan-replan; do
+  if ! grep -Fq "| \`$fixture\` |" "$coverage"; then
+    echo "coverage inventory is missing fixture: $fixture" >&2
+    exit 1
+  fi
+  if ! grep -Eq '^Status: (active|opt-in|negative|scaffold-only)' "$repo_root/$fixture/README.md"; then
+    echo "fixture README lacks active/opt-in/negative/scaffold-only status: $fixture" >&2
+    exit 1
+  fi
+done
+
+test -f "$repo_root/custom-workflows/custom-plan-replan/plan-generation-marker.sh"
+grep -Fq 'sh plan-generation-marker.sh' "$config"
+grep -Fq 'ATLANTIS_E2E_MIXED_BUILTIN_APPLY_MUST_NOT_RUN' "$config"
+
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [upstream-e2e-testcase.go]" >&2
+  exit 1
+fi
+if [ "$#" -eq 1 ]; then
+  upstream_testcases=$1
+  if [ ! -f "$upstream_testcases" ]; then
+    echo "upstream E2E testcase file does not exist: $upstream_testcases" >&2
+    exit 1
+  fi
+  sed -n 's/^[[:space:]]*Dir:[[:space:]]*"\([^"]*\)".*/\1/p' "$upstream_testcases" | sort -u >"$tmp_dir/e2e-dirs"
+  while IFS= read -r dir; do
+    if [ ! -d "$repo_root/$dir" ]; then
+      echo "upstream E2E references missing fixture directory: $dir" >&2
+      exit 1
+    fi
+  done <"$tmp_dir/e2e-dirs"
+
+  sed -n 's/.*atlantis\/\(plan\|apply\): \([^"}]*\).*/\2/p' "$upstream_testcases" | sort -u >"$tmp_dir/e2e-projects"
+  while IFS= read -r project; do
+    case "$project" in
+      */*) continue ;;
+    esac
+    if ! grep -Fq "    name: $project" "$config"; then
+      echo "upstream E2E references undefined Atlantis project: $project" >&2
+      exit 1
+    fi
+  done <"$tmp_dir/e2e-projects"
+fi
+
+echo "fixture consistency validation passed"


### PR DESCRIPTION
## Summary

- add built-in and run-only custom plan-generation replan fixtures
- add a negative mixed workflow that mutates Atlantis's managed plan before built-in apply
- validate fixture directories, project/workflow references, documentation status, markers, and optional upstream E2E case references
- document which regression lifecycles are active versus expected-failure coverage

## References

- runatlantis/atlantis#6657
- runatlantis/atlantis#6641
- runatlantis/atlantis#6642
- follows runatlantis/atlantis-tests#21611

The new fixtures are activated by the coordinated E2E runner changes in runatlantis/atlantis#6657.
