### PR TITLE
test: cover nested custom plan artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GitHub or GitLab E2E jobs; opt-in cases require `E2E_OPT_IN=1`.
 | `multi-projects/` | Explicit projects and `when_modified` fan-out | Active project/fan-out cases; workspace case opt-in |
 | `autodiscovery/` | Autodiscovery and explicit precedence | Included project active; explicit precedence opt-in |
 | `detection/` | `.tf`, `.tf.json`, OpenTofu detection | `.tf.json` active; OpenTofu disabled; others fixture-only |
-| `custom-workflows/` | Hook environment and user-managed plan paths | Custom path and custom replan lifecycles active on GitHub |
+| `custom-workflows/` | Hook environment and user-managed plan paths | Nested custom-path generic apply and custom replan lifecycles active on GitHub |
 | `output/` | Plan output rendering | Long-line active; failure disabled; heredoc fixture-only |
 | `locking/` | `repo_locks.mode: on_apply` preservation | Opt-in two-PR plan/apply lifecycle |
 | `drift/` | Drift detection API scaffolding | Disabled until the server flag is available in E2E |

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -118,14 +118,19 @@ workflows:
   custom-plan-path:
     plan:
       steps:
+        - run: mkdir -p generated/dev generated/staging
         - run: terraform init -input=false -no-color
-        - run: terraform plan -input=false -no-color -out=custom-atlantis.tfplan
-        - run: test -f custom-atlantis.tfplan
-        - run: echo ATLANTIS_E2E_CUSTOM_PLAN_CREATED
+        - run: terraform plan -input=false -no-color -out=generated/dev/atlantis.tfplan
+        - run: terraform plan -input=false -no-color -out=generated/staging/atlantis.tfplan
+        - run: test -f generated/dev/atlantis.tfplan && test -f generated/staging/atlantis.tfplan
+        - run: test ! -e custom-plan-path-default.tfplan
+        - run: echo ATLANTIS_E2E_CUSTOM_PLAN_CREATED generated/dev/atlantis.tfplan generated/staging/atlantis.tfplan
     apply:
       steps:
-        - run: test -f custom-atlantis.tfplan
-        - run: terraform apply -input=false -no-color custom-atlantis.tfplan
+        - run: test -f generated/dev/atlantis.tfplan && test -f generated/staging/atlantis.tfplan
+        - run: test ! -e custom-plan-path-default.tfplan
+        - run: terraform apply -input=false -no-color generated/dev/atlantis.tfplan
+        - run: test -f generated/dev/atlantis.tfplan && test -f generated/staging/atlantis.tfplan && test ! -e custom-plan-path-default.tfplan
         - run: echo ATLANTIS_E2E_CUSTOM_PLAN_APPLY_OK
 
   custom-plan-replan:

--- a/custom-workflows/README.md
+++ b/custom-workflows/README.md
@@ -7,7 +7,7 @@ Tests custom workflow execution, hook environment variables, and user-managed pl
 - **PROJECT_NAME env var**: Pre-plan hook asserts `$PROJECT_NAME` is set correctly
 - **Custom workflow steps**: `run` step executes before `init`/`plan`
 - **Script validation**: POSIX shell script with clear pass/fail output
-- **Custom plan path apply**: v0.46.0 regression coverage for Atlantis #6642
+- **Nested custom plan apply**: v0.46.0 generic-apply regression coverage for Atlantis #6642
 - **Custom plan replan**: two generations at a user-managed path with targeted apply
 
 ## Workflow Definition (in root atlantis.yaml)
@@ -24,14 +24,19 @@ workflows:
   custom-plan-path:
     plan:
       steps:
+        - run: mkdir -p generated/dev generated/staging
         - run: terraform init -input=false -no-color
-        - run: terraform plan -input=false -no-color -out=custom-atlantis.tfplan
-        - run: test -f custom-atlantis.tfplan
-        - run: echo ATLANTIS_E2E_CUSTOM_PLAN_CREATED
+        - run: terraform plan -input=false -no-color -out=generated/dev/atlantis.tfplan
+        - run: terraform plan -input=false -no-color -out=generated/staging/atlantis.tfplan
+        - run: test -f generated/dev/atlantis.tfplan && test -f generated/staging/atlantis.tfplan
+        - run: test ! -e custom-plan-path-default.tfplan
+        - run: echo ATLANTIS_E2E_CUSTOM_PLAN_CREATED generated/dev/atlantis.tfplan generated/staging/atlantis.tfplan
     apply:
       steps:
-        - run: test -f custom-atlantis.tfplan
-        - run: terraform apply -input=false -no-color custom-atlantis.tfplan
+        - run: test -f generated/dev/atlantis.tfplan && test -f generated/staging/atlantis.tfplan
+        - run: test ! -e custom-plan-path-default.tfplan
+        - run: terraform apply -input=false -no-color generated/dev/atlantis.tfplan
+        - run: test -f generated/dev/atlantis.tfplan && test -f generated/staging/atlantis.tfplan && test ! -e custom-plan-path-default.tfplan
         - run: echo ATLANTIS_E2E_CUSTOM_PLAN_APPLY_OK
 
   custom-plan-replan:
@@ -55,8 +60,10 @@ workflows:
 3. If env var missing or wrong → plan fails with "FAIL:" marker
 4. If correct → prints "PASS:" and continues to init/plan
 
-For `custom-plan-path`, the runner waits for the custom autoplan marker, posts
-`atlantis apply -p custom-plan-path`, and requires the apply marker from a new comment.
+For `custom-plan-path`, the runner waits for the custom autoplan marker, posts plain
+`atlantis apply`, and requires the apply marker from a new comment. The workflow
+creates two user-managed plans below `generated/dev` and `generated/staging`, applies
+the `dev` plan, and checks that Atlantis never creates its root convention plan.
 
 For `custom-plan-replan`, the runner overwrites `generation.auto.tfvars`, requires
 the generation-2 plan marker in a new comment, and then applies the targeted custom

--- a/custom-workflows/custom-plan-path/README.md
+++ b/custom-workflows/custom-plan-path/README.md
@@ -3,15 +3,22 @@
 Regression fixture for [runatlantis/atlantis#6642](https://github.com/runatlantis/atlantis/issues/6642),
 introduced in Atlantis v0.46.0.
 
-Both plan and apply use only custom `run` steps. The workflow writes
-`custom-atlantis.tfplan`; it never references `$PLANFILE` and never creates Atlantis's
-convention-named plan file.
+Both plan and apply use only custom `run` steps. The workflow writes two user-managed
+plan files below descendant directories:
 
-The upstream runner targets the project explicitly because generic apply discovers
-convention-named plan files by design:
+- `generated/dev/atlantis.tfplan`
+- `generated/staging/atlantis.tfplan`
+
+It never references `$PLANFILE` and explicitly checks that Atlantis's root-level
+`custom-plan-path-default.tfplan` convention plan does not exist.
+
+The upstream runner uses generic apply to prove Atlantis assigns both descendant
+artifacts to this single configured root project:
 
 ```text
-atlantis apply -p custom-plan-path
+atlantis apply
 ```
 
-The apply must emit `ATLANTIS_E2E_CUSTOM_PLAN_APPLY_OK`.
+The apply verifies both plans are still present, applies the `generated/dev` plan,
+and must emit `ATLANTIS_E2E_CUSTOM_PLAN_APPLY_OK` without creating a descendant
+pseudo-project.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -17,7 +17,7 @@ on a plan-only case is intentionally not executed.
 | `apply-regressions/builtin-autoplan-apply` | Built-in autoplan immediately followed by targeted built-in apply; Atlantis v0.46.0 regression [#6641](https://github.com/runatlantis/atlantis/issues/6641) | Active plan-then-apply on GitHub |
 | `apply-regressions/builtin-replan-apply` | Built-in generation 1, built-in generation 2, then targeted apply of generation 2 | Active plan-replan-apply on GitHub |
 | `apply-regressions/mixed-plan-mutation` | Custom pre-apply step mutates `$PLANFILE`; built-in apply must be rejected | Active expected-apply-failure on GitHub |
-| `custom-workflows/custom-plan-path` | Run-only plan/apply using `custom-atlantis.tfplan`, never `$PLANFILE`; Atlantis v0.46.0 regression [#6642](https://github.com/runatlantis/atlantis/issues/6642) | Active targeted plan-then-apply on GitHub |
+| `custom-workflows/custom-plan-path` | Run-only plan/apply using nested `generated/{dev,staging}/atlantis.tfplan` artifacts, never `$PLANFILE`; Atlantis v0.46.0 regression [#6642](https://github.com/runatlantis/atlantis/issues/6642) | Active generic plan-then-apply on GitHub |
 | `custom-workflows/custom-plan-replan` | Two run-only plan generations at `custom-replan.tfplan`, then targeted apply of generation 2 | Active plan-replan-apply on GitHub |
 | `multi-projects/project1` | Explicit project selection | Active on GitHub |
 | `multi-projects/shared-module` | `when_modified` fan-out to project1 and project2 | Active on GitHub |
@@ -53,16 +53,19 @@ containing `ATLANTIS_E2E_BUILTIN_AUTOPLAN_APPLY_OK`.
 
 ### Custom plan path apply (#6642)
 
-Both workflow stages contain only `run` steps. The plan is written to
-`custom-atlantis.tfplan`; the workflow does not reference or create `$PLANFILE`.
-The runner verifies the custom plan marker, posts:
+Both workflow stages contain only `run` steps. The plan stage writes
+`generated/dev/atlantis.tfplan` and `generated/staging/atlantis.tfplan`; the workflow
+does not reference or create `$PLANFILE` or Atlantis's root convention plan. The
+runner verifies the custom plan marker, posts:
 
 ```text
-atlantis apply -p custom-plan-path
+atlantis apply
 ```
 
-It then requires a new successful aggregate/project apply result and a new comment
-containing `ATLANTIS_E2E_CUSTOM_PLAN_APPLY_OK`.
+It then requires exactly the configured root project's apply context, a new successful
+aggregate/project apply result, and a new comment containing
+`ATLANTIS_E2E_CUSTOM_PLAN_APPLY_OK`. The workflow checks both nested artifacts remain
+available and applies the `generated/dev` plan.
 
 ### Built-in and custom replan to latest apply
 

--- a/scripts/validate-fixture-consistency.sh
+++ b/scripts/validate-fixture-consistency.sh
@@ -61,6 +61,31 @@ test -f "$repo_root/custom-workflows/custom-plan-replan/plan-generation-marker.s
 grep -Fq 'sh plan-generation-marker.sh' "$config"
 grep -Fq 'ATLANTIS_E2E_MIXED_BUILTIN_APPLY_MUST_NOT_RUN' "$config"
 
+awk '
+  /^  custom-plan-path:/ { in_workflow = 1; next }
+  in_workflow && /^  [A-Za-z0-9_-]+:/ { exit }
+  in_workflow { print }
+' "$config" >"$tmp_dir/custom-plan-path-workflow"
+for plan in generated/dev/atlantis.tfplan generated/staging/atlantis.tfplan; do
+  grep -Fq -- "-out=$plan" "$tmp_dir/custom-plan-path-workflow"
+  grep -Fq "test -f $plan" "$tmp_dir/custom-plan-path-workflow"
+done
+if [ "$(grep -Fc -- '-out=' "$tmp_dir/custom-plan-path-workflow")" -ne 2 ]; then
+  echo "custom plan path workflow must create exactly two nested plan artifacts" >&2
+  exit 1
+fi
+grep -Fq 'terraform apply -input=false -no-color generated/dev/atlantis.tfplan' "$tmp_dir/custom-plan-path-workflow"
+if [ "$(grep -Fc 'terraform apply ' "$tmp_dir/custom-plan-path-workflow")" -ne 1 ]; then
+  echo "custom plan path workflow must apply exactly one nested plan" >&2
+  exit 1
+fi
+grep -Fq 'test ! -e custom-plan-path-default.tfplan' "$tmp_dir/custom-plan-path-workflow"
+if grep -Fq 'custom-atlantis.tfplan' "$tmp_dir/custom-plan-path-workflow" ||
+  grep -Fq "\$PLANFILE" "$tmp_dir/custom-plan-path-workflow"; then
+  echo "custom plan path workflow still uses an Atlantis-managed plan path" >&2
+  exit 1
+fi
+
 if [ "$#" -gt 1 ]; then
   echo "usage: $0 [upstream-e2e-testcase.go]" >&2
   exit 1
@@ -89,6 +114,16 @@ if [ "$#" -eq 1 ]; then
       exit 1
     fi
   done <"$tmp_dir/e2e-projects"
+
+  custom_case=$(sed -n '/Name:.*"custom-plan-path-apply"/,/^\t},/p' "$upstream_testcases")
+  if ! printf '%s\n' "$custom_case" | grep -Fq 'ApplyCommand:                  "atlantis apply"'; then
+    echo "upstream custom plan path case must use generic atlantis apply" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$custom_case" | grep -Fq 'ATLANTIS_E2E_CUSTOM_PLAN_CREATED generated/dev/atlantis.tfplan generated/staging/atlantis.tfplan'; then
+    echo "upstream custom plan path case must require both nested plan artifacts" >&2
+    exit 1
+  fi
 fi
 
 echo "fixture consistency validation passed"

--- a/scripts/validate-fixture-consistency.sh
+++ b/scripts/validate-fixture-consistency.sh
@@ -80,6 +80,7 @@ if [ "$(grep -Fc 'terraform apply ' "$tmp_dir/custom-plan-path-workflow")" -ne 1
   exit 1
 fi
 grep -Fq 'test ! -e custom-plan-path-default.tfplan' "$tmp_dir/custom-plan-path-workflow"
+grep -Fq 'echo ATLANTIS_E2E_CUSTOM_PLAN_CREATED generated/dev/atlantis.tfplan generated/staging/atlantis.tfplan' "$tmp_dir/custom-plan-path-workflow"
 if grep -Fq 'custom-atlantis.tfplan' "$tmp_dir/custom-plan-path-workflow" ||
   grep -Fq "\$PLANFILE" "$tmp_dir/custom-plan-path-workflow"; then
   echo "custom plan path workflow still uses an Atlantis-managed plan path" >&2
@@ -118,10 +119,6 @@ if [ "$#" -eq 1 ]; then
   custom_case=$(sed -n '/Name:.*"custom-plan-path-apply"/,/^\t},/p' "$upstream_testcases")
   if ! printf '%s\n' "$custom_case" | grep -Fq 'ApplyCommand:                  "atlantis apply"'; then
     echo "upstream custom plan path case must use generic atlantis apply" >&2
-    exit 1
-  fi
-  if ! printf '%s\n' "$custom_case" | grep -Fq 'ATLANTIS_E2E_CUSTOM_PLAN_CREATED generated/dev/atlantis.tfplan generated/staging/atlantis.tfplan'; then
-    echo "upstream custom plan path case must require both nested plan artifacts" >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary

- update the run-only custom-plan fixture to create plans in two descendant directories
- keep the hosted lifecycle on plain `atlantis apply` and verify only the root project applies
- assert both user-managed artifacts survive and Atlantis never creates its convention plan
- align fixture documentation and consistency checks with the nested topology

## Notes

After this fixture merges, rerun the `e2e-github` job on runatlantis/atlantis#6657 so that its final hosted acceptance uses the nested-artifact topology rather than the previous root-level fixture.

## References

- runatlantis/atlantis#6642
- runatlantis/atlantis#6657
